### PR TITLE
feat: add hostname tag on the metrics emitted  from raccoon service

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.10
     steps:
       - name: Setup Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker-practice/actions-setup-docker@master
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Copy integration config

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-docker-action@v4
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Copy integration config

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.10
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker/setup-buildx-action@v3
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Copy integration config

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker/setup-docker-action@v4
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Copy integration config

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ test_ci: setup test
 # Docker Run
 
 docker-run:
-	docker-compose build
-	docker-compose up -d
+	docker compose up -d --build
 
 docker-stop:
 	docker-compose stop

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -45,15 +45,15 @@ func withTags(bucket, tags string) string {
 
 func Setup() error {
 	if instance == nil {
-		hostName, err := os.Hostname()
+		tagKey := "host:"
+		tagValue, err := os.Hostname()
 		if err != nil {
 			logger.Errorf("unable to get the host name during StatsD setup: %s", err.Error())
 			return err
 		}
-		hostNameTag := "host:" + hostName
 		c, err := client.New(
 			client.Address(config.MetricStatsd.Address),
-			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags([]string{hostNameTag}...))
+			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags(tagKey, tagValue))
 		if err != nil {
 			logger.Errorf("StatsD Set up failed to create client: %s", err.Error())
 			return err

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -45,15 +45,15 @@ func withTags(bucket, tags string) string {
 
 func Setup() error {
 	if instance == nil {
-		tagKey := "host:"
-		tagValue, err := os.Hostname()
+		hostTagKey := "host:"
+		hostTagValue, err := os.Hostname()
 		if err != nil {
 			logger.Errorf("unable to get the host name during StatsD setup: %s", err.Error())
 			return err
 		}
 		c, err := client.New(
 			client.Address(config.MetricStatsd.Address),
-			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags(tagKey, tagValue))
+			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags(hostTagKey, hostTagValue))
 		if err != nil {
 			logger.Errorf("StatsD Set up failed to create client: %s", err.Error())
 			return err

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -53,7 +53,7 @@ func Setup() error {
 		hostNameTag := "host:" + hostName
 		c, err := client.New(
 			client.Address(config.MetricStatsd.Address),
-			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags(hostNameTag))
+			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags([]string{hostNameTag}...))
 		if err != nil {
 			logger.Errorf("StatsD Set up failed to create client: %s", err.Error())
 			return err

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/goto/raccoon/config"
 	"github.com/goto/raccoon/logger"
@@ -44,9 +45,15 @@ func withTags(bucket, tags string) string {
 
 func Setup() error {
 	if instance == nil {
+		hostName, err := os.Hostname()
+		if err != nil {
+			logger.Errorf("unable to get the host name during StatsD setup: %s", err.Error())
+			return err
+		}
+		hostNameTag := "host:" + hostName
 		c, err := client.New(
 			client.Address(config.MetricStatsd.Address),
-			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs))
+			client.FlushPeriod(config.MetricStatsd.FlushPeriodMs), client.Tags(hostNameTag))
 		if err != nil {
 			logger.Errorf("StatsD Set up failed to create client: %s", err.Error())
 			return err


### PR DESCRIPTION
The hostname is fetched using the native `os` golang lib. This metric tag will be added to each metric now. 
This has been added as part of statsD client setup.

The integration test is failing due to the use of outdated `docker-practice/actions-setup-docker@master`  github action
refer: https://github.com/docker-practice/actions-setup-docker/issues/41

`docker-compose build ` and `docker-compose up -d` commands are combined into a single command `docker compose up -d --build` in the make file As `docker-compose build ` was giving "No such file or directory" post changing the github action on integration test workflow