### PR TITLE
feat: add latency metric for better observability (#40)

### DIFF
--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -74,8 +74,11 @@ func Count(bucket string, i int, tags string) {
 }
 
 func Timing(bucket string, t int64, tags string) {
-	err := Setup()
-	if err == nil {
+	if Setup() != nil {
+		return
+	}
+
+	if t >= 0 {
 		instance.timing(bucket, t, tags)
 	}
 }

--- a/publisher/kafka.go
+++ b/publisher/kafka.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 	// Importing librd to make it work on vendor mode
@@ -23,7 +24,11 @@ const (
 // KafkaProducer Produce data to kafka synchronously
 type KafkaProducer interface {
 	// ProduceBulk message to kafka. Block until all messages are sent. Return array of error. Order is not guaranteed.
-	ProduceBulk(events []*pb.Event, connGroup string, deliveryChannel chan kafka.Event) error
+	ProduceBulk(
+		events []*pb.Event, connGroup string, deliveryChannel chan kafka.Event,
+		startTimeClient, startTimeServer, startTimeWorker time.Time,
+	) error
+
 	HealthCheck() error
 }
 
@@ -67,7 +72,16 @@ type Kafka struct {
 
 // ProduceBulk messages to kafka. Block until all messages are sent. Return array of error. Order of Errors is guaranteed.
 // DeliveryChannel needs to be exclusive. DeliveryChannel is exposed for recyclability purpose.
-func (pr *Kafka) ProduceBulk(events []*pb.Event, connGroup string, deliveryChannel chan kafka.Event) error {
+//
+// startTimeClient: represents the event send time specified by client
+// startTimeServer: represents the time when the event is received by raccoon server
+// startTimeWorker: represents the time when the event is picked up by worker to be sent to kafka
+func (pr *Kafka) ProduceBulk(
+	events []*pb.Event, connGroup string, deliveryChannel chan kafka.Event,
+	startTimeClient, startTimeServer, startTimeWorker time.Time,
+) error {
+	startTimeEvents := make([]time.Time, len(events))
+
 	errors := make([]error, len(events))
 	totalProcessed := 0
 	for order, event := range events {
@@ -86,6 +100,19 @@ func (pr *Kafka) ProduceBulk(events []*pb.Event, connGroup string, deliveryChann
 			event.GetEventTimestamp().AsTime().String(),
 			fmt.Sprintf("%t", event.GetIsExclusive()),
 		)
+
+		metrics.Increment(
+			"clickstream_event_routed_total",
+			fmt.Sprintf(
+				"conn_group=%s,event_type=%s,topic=%s,is_exclusive=%t",
+				connGroup,
+				event.Type,
+				topic,
+				event.GetIsExclusive(),
+			),
+		)
+
+		startTimeEvents[order] = time.Now()
 
 		err := pr.kp.Produce(message, deliveryChannel)
 		if err != nil {
@@ -122,16 +149,34 @@ func (pr *Kafka) ProduceBulk(events []*pb.Event, connGroup string, deliveryChann
 	for i := 0; i < totalProcessed; i++ {
 		d := <-deliveryChannel
 		m := d.(*kafka.Message)
+
+		order, ok := m.Opaque.(int)
+		if !ok {
+			logger.Errorf("failed to cast kafka event opaque to int for conn_group=%s, skipping processing the delivery report for this message", connGroup)
+			continue
+		}
+
+		event := events[order]
 		if m.TopicPartition.Error != nil {
 			eventType := events[i].Type
 			metrics.Decrement("kafka_messages_delivered_total", fmt.Sprintf("success=true,conn_group=%s,event_type=%s", connGroup, eventType))
 			metrics.Increment("kafka_messages_delivered_total", fmt.Sprintf("success=false,conn_group=%s,event_type=%s", connGroup, eventType))
 			metrics.Increment("kafka_error", fmt.Sprintf("type=%s,event_type=%s,conn_group=%s", "delivery_failed", eventType, connGroup))
 			metrics.Increment("clickstream_data_loss", fmt.Sprintf("reason=%s,event_name=%s,product=%s,conn_group=%s",
-				"delivery_failed", events[i].EventName, strings.ReplaceAll(strings.ToLower(events[i].Product), "_", ""), connGroup,
+				"delivery_failed", event.EventName, strings.ReplaceAll(strings.ToLower(event.Product), "_", ""), connGroup,
 			))
 			order := m.Opaque.(int)
 			errors[order] = m.TopicPartition.Error
+		} else {
+			startTimeEvent := startTimeEvents[order]
+
+			// granular metric, el: event level
+			metrics.Timing("el_kafka_processing_duration_milliseconds", time.Since(startTimeEvent).Milliseconds(), fmt.Sprintf("conn_group=%s,event_type=%s", connGroup, event.Type))
+
+			// grouped metric, el: event level
+			metrics.Timing("el_worker_processing_duration_milliseconds", time.Since(startTimeWorker).Milliseconds(), fmt.Sprintf("conn_group=%s,event_type=%s", connGroup, event.Type))
+			metrics.Timing("el_server_processing_duration_milliseconds", time.Since(startTimeServer).Milliseconds(), fmt.Sprintf("conn_group=%s,event_type=%s", connGroup, event.Type))
+			metrics.Timing("el_event_processing_duration_milliseconds", time.Since(startTimeClient).Milliseconds(), fmt.Sprintf("conn_group=%s,event_type=%s", connGroup, event.Type))
 		}
 	}
 

--- a/publisher/kafka_test.go
+++ b/publisher/kafka_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	pb "buf.build/gen/go/gotocompany/proton/protocolbuffers/go/gotocompany/raccoon/v1beta1"
 	"github.com/goto/raccoon/logger"
@@ -27,112 +28,116 @@ func TestMain(t *testing.M) {
 }
 
 func TestProducer_Close(suite *testing.T) {
-    suite.Run("Should flush before closing the client", func(t *testing.T) {
-        client := &mockClient{}
-        client.On("Flush", 10).Return(0)
-        client.On("Close").Return()
-        kp := NewKafkaFromClient(client, 10, map[bool]string{true: "%s", false: "%s"})
-        kp.Close()
-        client.AssertExpectations(t)
-    })
+	suite.Run("Should flush before closing the client", func(t *testing.T) {
+		client := &mockClient{}
+		client.On("Flush", 10).Return(0)
+		client.On("Close").Return()
+		kp := NewKafkaFromClient(client, 10, map[bool]string{true: "%s", false: "%s"})
+		kp.Close()
+		client.AssertExpectations(t)
+	})
 }
 
 func TestKafka_ProduceBulk(suite *testing.T) {
-    suite.Parallel()
-    topic := "test_topic"
-    testFormat := map[bool]string{true: "%s", false: "%s"}
+	suite.Parallel()
+	topic := "test_topic"
+	testFormat := map[bool]string{true: "%s", false: "%s"}
 
-    suite.Run("AllMessagesSuccessfulProduce", func(t *testing.T) {
-        t.Run("Should return nil when all message succesfully published", func(t *testing.T) {
-            client := &mockClient{}
-            client.On("Produce", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-                go func() {
-                    args.Get(1).(chan kafka.Event) <- &kafka.Message{
-                        TopicPartition: kafka.TopicPartition{
-                            Topic:     args.Get(0).(*kafka.Message).TopicPartition.Topic,
-                            Partition: 0,
-                            Offset:    0,
-                            Error:     nil,
-                        },
-                    }
-                }()
-            })
-            kp := NewKafkaFromClient(client, 10, testFormat)
+	now := time.Now()
 
-            err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}}, group1, make(chan kafka.Event, 2))
-            assert.NoError(t, err)
-        })
-    })
+	suite.Run("AllMessagesSuccessfulProduce", func(t *testing.T) {
+		t.Run("Should return nil when all message succesfully published", func(t *testing.T) {
+			client := &mockClient{}
+			client.On("Produce", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				go func() {
+					args.Get(1).(chan kafka.Event) <- &kafka.Message{
+						TopicPartition: kafka.TopicPartition{
+							Topic:     args.Get(0).(*kafka.Message).TopicPartition.Topic,
+							Partition: 0,
+							Offset:    0,
+							Error:     nil,
+						},
+						Opaque: 0,
+					}
+				}()
+			})
+			kp := NewKafkaFromClient(client, 10, testFormat)
 
-    suite.Run("PartialSuccessfulProduce", func(t *testing.T) {
-        t.Run("Should process non producer error messages", func(t *testing.T) {
-            client := &mockClient{}
-            client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf("buffer full")).Once()
-            client.On("Produce", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-                go func() {
-                    args.Get(1).(chan kafka.Event) <- &kafka.Message{
-                        TopicPartition: kafka.TopicPartition{
-                            Topic:     args.Get(0).(*kafka.Message).TopicPartition.Topic,
-                            Partition: 0,
-                            Offset:    0,
-                            Error:     nil,
-                        },
-                    }
-                }()
-            }).Once()
-            client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf("buffer full")).Once()
-            kp := NewKafkaFromClient(client, 10, testFormat)
+			err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}}, group1, make(chan kafka.Event, 2), now, now, now)
+			assert.NoError(t, err)
+		})
+	})
 
-            err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}}, group1, make(chan kafka.Event, 2))
-            assert.Len(t, err.(BulkError).Errors, 3)
-            assert.Error(t, err.(BulkError).Errors[0])
-            assert.Empty(t, err.(BulkError).Errors[1])
-            assert.Error(t, err.(BulkError).Errors[2])
-        })
+	suite.Run("PartialSuccessfulProduce", func(t *testing.T) {
+		t.Run("Should process non producer error messages", func(t *testing.T) {
+			client := &mockClient{}
+			client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf("buffer full")).Once()
+			client.On("Produce", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				go func() {
+					args.Get(1).(chan kafka.Event) <- &kafka.Message{
+						TopicPartition: kafka.TopicPartition{
+							Topic:     args.Get(0).(*kafka.Message).TopicPartition.Topic,
+							Partition: 0,
+							Offset:    0,
+							Error:     nil,
+						},
+						Opaque: 1,
+					}
+				}()
+			}).Once()
+			client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf("buffer full")).Once()
+			kp := NewKafkaFromClient(client, 10, testFormat)
 
-        t.Run("Should return topic name when unknown topic is returned", func(t *testing.T) {
-            client := &mockClient{}
-            client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf(errUnknownTopic)).Once()
-            kp := NewKafkaFromClient(client, 10, testFormat)
+			err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}}, group1, make(chan kafka.Event, 2), now, now, now)
+			assert.Len(t, err.(BulkError).Errors, 3)
+			assert.Error(t, err.(BulkError).Errors[0])
+			assert.Empty(t, err.(BulkError).Errors[1])
+			assert.Error(t, err.(BulkError).Errors[2])
+		})
 
-            err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}}, "group1", make(chan kafka.Event, 2))
-            assert.EqualError(t, err.(BulkError).Errors[0], errUnknownTopic+" "+topic)
-        })
+		t.Run("Should return topic name when unknown topic is returned", func(t *testing.T) {
+			client := &mockClient{}
+			client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf(errUnknownTopic)).Once()
+			kp := NewKafkaFromClient(client, 10, testFormat)
 
-        t.Run("Should return topic name when message size is too large", func(t *testing.T) {
-            client := &mockClient{}
-            client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf(errLargeMessageSize)).Once()
-            kp := NewKafkaFromClient(client, 10, testFormat)
+			err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}}, "group1", make(chan kafka.Event, 2), now, now, now)
+			assert.EqualError(t, err.(BulkError).Errors[0], errUnknownTopic+" "+topic)
+		})
 
-            err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}}, "group1", make(chan kafka.Event, 2))
-            assert.EqualError(t, err.(BulkError).Errors[0], errLargeMessageSize+" "+topic)
-        })
-    })
+		t.Run("Should return topic name when message size is too large", func(t *testing.T) {
+			client := &mockClient{}
+			client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf(errLargeMessageSize)).Once()
+			kp := NewKafkaFromClient(client, 10, testFormat)
 
-    suite.Run("MessageFailedToProduce", func(t *testing.T) {
-        t.Run("Should fill all errors when all messages fail", func(t *testing.T) {
-            client := &mockClient{}
-            client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf("buffer full")).Once()
-            client.On("Produce", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-                go func() {
-                    args.Get(1).(chan kafka.Event) <- &kafka.Message{
-                        TopicPartition: kafka.TopicPartition{
-                            Topic:     args.Get(0).(*kafka.Message).TopicPartition.Topic,
-                            Partition: 0,
-                            Offset:    0,
-                            Error:     fmt.Errorf("timeout"),
-                        },
-                        Opaque: 1,
-                    }
-                }()
-            }).Once()
-            kp := NewKafkaFromClient(client, 10, testFormat)
+			err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}}, "group1", make(chan kafka.Event, 2), now, now, now)
+			assert.EqualError(t, err.(BulkError).Errors[0], errLargeMessageSize+" "+topic)
+		})
+	})
 
-            err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}}, "group1", make(chan kafka.Event, 2))
-            assert.NotEmpty(t, err)
-            assert.Len(t, err.(BulkError).Errors, 2)
-            assert.Equal(t, "buffer full", err.(BulkError).Errors[0].Error())
-            assert.Equal(t, "timeout", err.(BulkError).Errors[1].Error())
-        })
-    })
+	suite.Run("MessageFailedToProduce", func(t *testing.T) {
+		t.Run("Should fill all errors when all messages fail", func(t *testing.T) {
+			client := &mockClient{}
+			client.On("Produce", mock.Anything, mock.Anything).Return(fmt.Errorf("buffer full")).Once()
+			client.On("Produce", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				go func() {
+					args.Get(1).(chan kafka.Event) <- &kafka.Message{
+						TopicPartition: kafka.TopicPartition{
+							Topic:     args.Get(0).(*kafka.Message).TopicPartition.Topic,
+							Partition: 0,
+							Offset:    0,
+							Error:     fmt.Errorf("timeout"),
+						},
+						Opaque: 1,
+					}
+				}()
+			}).Once()
+			kp := NewKafkaFromClient(client, 10, testFormat)
+
+			err := kp.ProduceBulk([]*pb.Event{{EventBytes: []byte{}, Type: topic}, {EventBytes: []byte{}, Type: topic}}, "group1", make(chan kafka.Event, 2), now, now, now)
+			assert.NotEmpty(t, err)
+			assert.Len(t, err.(BulkError).Errors, 2)
+			assert.Equal(t, "buffer full", err.(BulkError).Errors[0].Error())
+			assert.Equal(t, "timeout", err.(BulkError).Errors[1].Error())
+		})
+	})
 }

--- a/services/grpc/handler.go
+++ b/services/grpc/handler.go
@@ -50,6 +50,9 @@ func (h *Handler) SendEvent(ctx context.Context, req *pb.SendEventRequest) (*pb.
 
 	timeConsumed := time.Now()
 
+	timing_event_received := timeConsumed.Sub(req.GetSentTime().AsTime()).Milliseconds()
+	metrics.Timing("event_received_duration_milliseconds", timing_event_received, fmt.Sprintf("conn_group=%s", identifier.Group))
+
 	metrics.Increment("batches_read_total", fmt.Sprintf("status=success,conn_group=%s", identifier.Group))
 	h.sendEventCounters(req.Events, identifier.Group)
 

--- a/services/mqtt/handler.go
+++ b/services/mqtt/handler.go
@@ -55,6 +55,9 @@ func (h *Handler) MQTTHandler(ctx context.Context, c courier.PubSub, message *co
 	h.recordMetrics("request", fmt.Sprintf("status=success,conn_group=%s", connGroup), reqBytes)
 	h.recordMetrics("event", fmt.Sprintf("conn_group=%s", connGroup), req.Events)
 
+	timing_event_received := start.Sub(req.GetSentTime().AsTime()).Milliseconds()
+	metrics.Timing("event_received_duration_milliseconds", timing_event_received, fmt.Sprintf("conn_group=%s", connGroup))
+
 	h.Collector.Collect(ctx, &collection.CollectRequest{
 		ConnectionIdentifier: identification.Identifier{Group: connGroup},
 		TimeConsumed:         start,

--- a/services/rest/websocket/handler.go
+++ b/services/rest/websocket/handler.go
@@ -112,6 +112,9 @@ func (h *Handler) HandlerWSEvents(w http.ResponseWriter, r *http.Request) {
 			h.upgrader.Table.StoreBatch(conn.Identifier, payload.ReqGuid)
 		}
 
+		timing_event_received := timeConsumed.Sub(payload.GetSentTime().AsTime()).Milliseconds()
+		metrics.Timing("event_received_duration_milliseconds", timing_event_received, fmt.Sprintf("conn_group=%s", conn.Identifier.Group))
+
 		metrics.Increment("batches_read_total", fmt.Sprintf("status=success,conn_group=%s", conn.Identifier.Group))
 		h.sendEventCounters(payload.Events, conn.Identifier.Group)
 

--- a/worker/mocks.go
+++ b/worker/mocks.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"time"
+
 	pb "buf.build/gen/go/gotocompany/proton/protocolbuffers/go/gotocompany/raccoon/v1beta1"
 	mock "github.com/stretchr/testify/mock"
 	kafka "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
@@ -12,8 +14,11 @@ type mockKafkaPublisher struct {
 }
 
 // ProduceBulk provides a mock function with given fields: events, deliveryChannel
-func (m *mockKafkaPublisher) ProduceBulk(events []*pb.Event, connGroup string, deliveryChannel chan kafka.Event) error {
-	mock := m.Called(events, connGroup, deliveryChannel)
+func (m *mockKafkaPublisher) ProduceBulk(
+	events []*pb.Event, connGroup string, deliveryChannel chan kafka.Event,
+	startTimeClient, startTimeServer, startTimeWorker time.Time,
+) error {
+	mock := m.Called(events, connGroup, deliveryChannel, startTimeClient, startTimeServer, startTimeWorker)
 	return mock.Error(0)
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -40,14 +40,16 @@ func (w *Pool) StartWorkers() {
 			logger.Info("Running worker: " + workerName)
 			deliveryChan := make(chan kafka.Event, w.deliveryChannelSize)
 			for request := range w.EventsChannel {
-				metrics.Timing("batch_idle_in_channel_milliseconds", (time.Now().Sub(request.TimePushed)).Milliseconds(), "worker="+workerName)
-				batchReadTime := time.Now()
+				startTimeWorker := time.Now()
+				tags := fmt.Sprintf("conn_group=%s", request.ConnectionIdentifier.Group)
+
+				metrics.Timing("event_idle_in_channel_duration_milliseconds", (startTimeWorker.Sub(request.TimePushed)).Milliseconds(), tags)
+
 				//@TODO - Should add integration tests to prove that the worker receives the same message that it produced, on the delivery channel it created
-
-				err := w.kafkaProducer.ProduceBulk(request.GetEvents(), request.ConnectionIdentifier.Group, deliveryChan)
-
-				produceTime := time.Since(batchReadTime)
-				metrics.Timing("kafka_producebulk_tt_ms", produceTime.Milliseconds(), "")
+				err := w.kafkaProducer.ProduceBulk(
+					request.GetEvents(), request.ConnectionIdentifier.Group, deliveryChan,
+					request.GetSentTime().AsTime(), request.TimeConsumed, startTimeWorker,
+				)
 
 				if request.AckFunc != nil {
 					request.AckFunc(err)
@@ -64,13 +66,6 @@ func (w *Pool) StartWorkers() {
 				}
 				lenBatch := int64(len(request.GetEvents()))
 				logger.Debug(fmt.Sprintf("Success sending messages, %v", lenBatch-int64(totalErr)))
-				if lenBatch > 0 {
-					eventTimingMs := time.Since(request.GetSentTime().AsTime()).Milliseconds() / lenBatch
-					metrics.Timing("event_processing_duration_milliseconds", eventTimingMs, fmt.Sprintf("conn_group=%s", request.ConnectionIdentifier.Group))
-					now := time.Now()
-					metrics.Timing("worker_processing_duration_milliseconds", (now.Sub(batchReadTime).Milliseconds())/lenBatch, "worker="+workerName)
-					metrics.Timing("server_processing_latency_milliseconds", (now.Sub(request.TimeConsumed)).Milliseconds()/lenBatch, fmt.Sprintf("conn_group=%s", request.ConnectionIdentifier.Group))
-				}
 			}
 			w.wg.Done()
 		}(fmt.Sprintf("worker-%d", i))

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -41,7 +41,7 @@ func TestWorker(t *testing.T) {
 			}
 			worker.StartWorkers()
 
-			kp.On("ProduceBulk", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+			kp.On("ProduceBulk", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 			bc <- *request
 			bc <- *request
 			time.Sleep(10 * time.Millisecond)
@@ -67,7 +67,7 @@ func TestWorker(t *testing.T) {
 				wg:                  sync.WaitGroup{},
 			}
 			worker.StartWorkers()
-			kp.On("ProduceBulk", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3).After(3 * time.Millisecond)
+			kp.On("ProduceBulk", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3).After(3 * time.Millisecond)
 			bc <- *request
 			bc <- *request
 			bc <- *request


### PR DESCRIPTION
* feat: adjust metric publish to use more standardized form

* feat: add metric to track the duration from sent to received in websocket

* feat: add metric to track the duration from sent to received in grpc

* feat: add metric to track the duration from sent to received in mqtt

* fix: replace negaive timing with 0

* fix: negative duration not replaced by zero but instead not published

* refactor: extract tags to variable

* fix!: rework how the event is published

* test: fix failure due to mock issue

* fix: possible panic when casting opaque to order

* chore: update metric name based on suggestion

* refactor: add logger to confirm the returned order

* fix: to differentiate between log request and response

* chore: add random value factor for pin point

* chore: remove unnecessary map and log after conclusion